### PR TITLE
Remove `paths` from CodeQL config.yml

### DIFF
--- a/config/codeql.yml
+++ b/config/codeql.yml
@@ -34,6 +34,3 @@ paths-ignore:
   - '**/jquery-*.js'
   # Python
   - '.env'
-
-paths:
-  - '/**/'


### PR DESCRIPTION
This caused problems for the Python extractor, which would cause it to not extract any files.

See the initial extractor failure at https://github.com/RasmusWL/vulpy/actions/workflows/codeql-analysis.yml when using the old config file, and the success (of extraction) after removing the `paths` in https://github.com/RasmusWL/vulpy/commit/b23902986edd33749b1a431a6fbed36f3a51eb7e

(query evaluation failed, but that was due to something else)