### PR TITLE
Fix `WeakHashingAlgorithms.ql` for Python

### DIFF
--- a/python/CWE-327/WeakHashingAlgorithms.ql
+++ b/python/CWE-327/WeakHashingAlgorithms.ql
@@ -14,9 +14,6 @@
 
 import python
 import semmle.python.Concepts
-import semmle.python.dataflow.new.DataFlow
-import semmle.python.dataflow.new.TaintTracking
-import DataFlow::PathGraph
 
 from Cryptography::CryptographicOperation operation, Cryptography::HashingAlgorithm algorithm
 where


### PR DESCRIPTION
Specifically the `import DataFlow::PathGraph` brought some query-predicates into scope, and this made the CodeQL CLI unhappy, which failed with the error:

```
A fatal error occurred: Could not process query metadata for /home/runner/work/_temp/advanced-security/codeql-queries/main/python/CWE-327/WeakHashingAlgorithms.ql.
Error was: Expected result pattern(s) are not present for problem query: Expected exactly one pattern. [INVALID_RESULT_PATTERNS]
```

see https://github.com/RasmusWL/vulpy/runs/5556193642?check_suite_focus=true#step:5:1298