### PR TITLE
Add config file for disabling default queries.

### DIFF
--- a/config/disable-default-queries.yml
+++ b/config/disable-default-queries.yml
@@ -1,0 +1,2 @@
+name: "Don't run the default language query packs"
+disable-default-queries: true


### PR DESCRIPTION
@GeekMasher This will allow one to bypass having to create a separate configuration file if all one wants to do is to disable the default queries. It will work for many but not all cases, but allows configurations such as [this](https://github.com/zbazztian/webgoat-scan/blob/a69cd08773c909c5ba3d064c3484b9d3a37d054d/.github/workflows/codeql-analysis.yml#L45-L48). One can think of it as a more verbose version of the future `disable-default-queries` property in workflows.