### PR TITLE
Python format string

### DIFF
--- a/python/CWE-133/format_string.ql
+++ b/python/CWE-133/format_string.ql
@@ -1,0 +1,22 @@
+/**
+ * @name Python user-controlled format string
+ * @description User-controlled format string can result in Denial-of-Service or information leaks
+ * @kind path-problem
+ * @problem.severity error
+ * @id python/format-string
+ * @precision low
+ * @tags format-string
+ *       python
+ *       external/cwe/cwe-134
+ *       external/cwe/cwe-133
+ */
+
+private import python
+private import semmle.python.dataflow.new.DataFlow
+private import DataFlow::PathGraph
+
+private import format_string
+
+from DataFlow::PathNode userdata, DataFlow::PathNode format_string, FormatStringTaintConfiguration format_string_config
+where format_string_config.hasFlowPath(userdata, format_string)
+select format_string.getNode(), userdata, format_string, "Untrusted data used as format string: $@.", userdata.getNode(), userdata.toString()

--- a/python/CWE-133/format_string.ql
+++ b/python/CWE-133/format_string.ql
@@ -19,4 +19,4 @@ private import format_string
 
 from DataFlow::PathNode userdata, DataFlow::PathNode format_string, FormatStringTaintConfiguration format_string_config
 where format_string_config.hasFlowPath(userdata, format_string)
-select format_string.getNode(), userdata, format_string, "Untrusted data used as format string: $@.", userdata.getNode(), userdata.toString()
+select format_string.getNode(), userdata, format_string, "$@ used as format string: $@.", userdata.getNode(), "Untrusted data", format_string, format_string.getNode().asExpr().toString()

--- a/python/CWE-133/format_string.ql
+++ b/python/CWE-133/format_string.ql
@@ -7,6 +7,7 @@
  * @precision low
  * @tags format-string
  *       python
+ *       security
  *       external/cwe/cwe-134
  *       external/cwe/cwe-133
  */

--- a/python/CWE-133/format_string.qll
+++ b/python/CWE-133/format_string.qll
@@ -1,0 +1,31 @@
+private import python
+
+private import semmle.python.dataflow.new.DataFlow
+private import semmle.python.dataflow.new.TaintTracking
+private import semmle.python.dataflow.new.RemoteFlowSources
+
+private import github.LocalSources
+
+class FormatStringTaintConfiguration extends TaintTracking::Configuration {
+    FormatStringTaintConfiguration() { this = "FormatStringTaintConfiguration" }
+    
+    override predicate isSource(DataFlow::Node source) {
+        source instanceof RemoteFlowSource
+        or
+        source instanceof LocalSources::Range
+    }
+    
+    override predicate isSink(DataFlow::Node sink) {
+        sink instanceof FormatString
+        and not sink.asExpr() instanceof StrConst
+    }
+}
+
+class FormatString extends DataFlow::Node {
+    FormatString() {
+        exists(CallNode call |
+            call.getFunction().(AttrNode).getName() = "format"
+            and call.getFunction().(AttrNode).getObject() = this.asCfgNode()
+        )
+    }
+}

--- a/python/github/LocalSources.qll
+++ b/python/github/LocalSources.qll
@@ -58,7 +58,7 @@ module LocalSources {
     }
   }
 
-  // Local Enviroment Variables
+  // Local Environment Variables
   class EnviromentVariablesSources extends LocalSources::Range {
     EnviromentVariablesSources() {
       exists(DataFlow::Node call |
@@ -82,15 +82,128 @@ module LocalSources {
   // Local File Reads
   class FileReadSource extends LocalSources::Range {
     FileReadSource() {
-      // exists(StrConst literal | this = DataFlow::exprNode(literal))
       exists(DataFlow::Node call |
         (
           // https://docs.python.org/3/library/functions.html#open
           // var = open('abc.txt')
-          call = API::builtin("open").getACall().getAMethodCall("read")
+          call = API::builtin("open").getACall().getAMethodCall(["read", "readline", "readlines"])
           or
           // https://docs.python.org/3/library/os.html#os.read
-          call = API::moduleImport("os").getMember(["read"]).getACall()
+          call = API::moduleImport("os").getMember("read").getACall()
+          or
+          // json.load
+          call = API::moduleImport(["json", "simplejson"]).getMember("load").getACall()
+          or
+          // yaml.load
+          call = API::moduleImport("yaml").getMember(["load", "load_all", "safe_load", "safe_load_all"]).getACall()
+          or
+          // msgpack.load
+          call = API::moduleImport("msgpack").getMember("load").getACall()
+          or
+          // pickle.load
+          // dill.load
+          call = API::moduleImport(["cPickle", "_pickle", "pickle", "dill"]).getMember("load").getACall()
+          or
+          // pickle.Unpickler.load
+          // dill.Unpickler.load
+          call = API::moduleImport(["cPickle", "pickle", "dill"]).getMember("Unpickler").getACall().getAMethodCall("load")
+          or
+          // shelve.open
+          call = API::moduleImport("shelve").getMember("open").getACall()
+          or
+          // numpy.loadtxt
+          call = API::moduleImport("numpy").getMember(["loadtxt", "genfromtxt"]).getACall()
+          or
+          // csv
+          call = API::moduleImport("csv").getMember(["reader", "DictReader"]).getACall()
+          or
+          // pandas.read_pickle
+          // pandas.read_table
+          // pandas.read_csv
+          // pandas.read_fwf
+          // pandas.read_excel
+          // pandas.read_json
+          // pandas.read_html
+          // pandas.read_xml
+          // pandas.read_hdf
+          // pandas.read_feather
+          // pandas.read_parquet
+          // pandas.read_orc
+          // pandas.read_sas
+          // pandas.read_spss
+          // pandas.read_sql_table
+          // pandas.read_sql_query
+          // pandas.read_sql
+          // pandas.read_gbq
+          // pandas.read_stata
+          // generate call expressions for each of the above pandas functions including ExcelFile.parse and HDFStore.* that have to be handled separately
+          call = API::moduleImport("pandas")
+                  .getMember([
+                      "read_csv", "read_fwf", "read_excel", "read_json", "read_html", "read_xml",
+                      "read_hdf", "read_feather", "read_parquet", "read_orc", "read_sas", "read_spss", "read_sql_table",
+                      "read_sql_query", "read_sql", "read_gbq", "read_stata"
+                    ])
+                  .getACall()
+          or
+          // pandas.ExcelFile.parse
+          call = API::moduleImport("pandas")
+                  .getMember("ExcelFile")
+                  .getACall()
+                  .getAMethodCall("parse")
+          or
+          // pandas.HDFStore.get
+          // pandas.HDFStore.select
+          // pandas.HDFStore.info
+          // pandas.HDFStore.keys
+          // pandas.HDFStore.groups
+          // pandas.HDFStore.walk
+          call = API::moduleImport("pandas")
+                  .getMember("HDFStore")
+                  .getACall()
+                  .getAMethodCall(["get", "select", "info", "keys", "groups", "walk"])
+          or
+          // polars.read_csv
+          call = API::moduleImport("polars").getMember(["read_csv", "read_csv_batched", "scan_csv"]).getACall()
+          or
+          // polars.read_ipc
+          call = API::moduleImport("polars").getMember(["read_ipc", "scan_ipc", "read_ipc_schema"]).getACall()
+          or
+          // polars.read_parquet, polars.scan_parquet, polars.read_parquet_schema
+          call = API::moduleImport("polars").getMember(["read_parquet", "scan_parquet", "read_parquet_schema"]).getACall()
+          or
+          // polars.read_sql
+          call = API::moduleImport("polars").getMember("read_sql").getACall()
+          or
+          // polars.read_json, polars.read_ndjson, polars.scan_ndjson
+          call = API::moduleImport("polars").getMember(["read_json", "read_ndjson", "scan_ndjson"]).getACall()
+          or
+          // polars.read_avro
+          call = API::moduleImport("polars").getMember("read_avro").getACall()
+          or
+          // polars.read_excel
+          call = API::moduleImport("polars").getMember("read_excel").getACall()
+          or
+          // pyarrow.csv.read_csv
+          // pyarrow.csv.open_csv
+          // pyarrow.csv.CSVStreamingReader
+          call = API::moduleImport("pyarrow").getMember("csv").getMember(["read_csv", "open_csv", "CSVStreamingReader"]).getACall()
+          or
+          // pyarrow.feather.read_feather
+          // pyarrow.feather.read_table
+          call = API::moduleImport("pyarrow").getMember("feather").getMember(["read_feather", "read_table"]).getACall()
+          or
+          // pyarrow.json.read_json
+          call = API::moduleImport("pyarrow").getMember("json").getMember("read_json").getACall()
+          // pyarrow.parquet.ParquetDataset
+          // pyarrow.parquet.ParquetFile
+          // pyarrow.parquet.read_table
+          // pyarrow.parquet.read_metadata
+          // pyarrow.parquet.read_pandas
+          // pyarrow.parquet.read_schema
+          or
+          call = API::moduleImport("pyarrow").getMember("parquet").getMember([
+              "ParquetDataset", "ParquetFile", "read_table", "read_metadata", "read_pandas", "read_schema"
+            ]).getACall()
         ) and
         this = call
       ) and


### PR DESCRIPTION
Created a format string query for untrusted input flowing to a use of `string.format(...)` function, e.g.

``` python
args = sensitive_data()
msg = untrusted_input()
...
print(msg.format(msg, args))
```

That would allow Denial-of-Service, and potentially leaking sensitive data.

I also added a lot of local input file sources, since `json.load` wasn't modelled.