### PR TITLE
Include new path-injection query into `java` custom suite

### DIFF
--- a/java/suites/codeql-java.qls
+++ b/java/suites/codeql-java.qls
@@ -14,6 +14,8 @@
       # Crypto
       - java/weak-cryptographic-algorithm
       - java/weak-encryption
+      # Improved Path Injection
+      - java/path-injection
 - exclude:
     tags contain:
       - static


### PR DESCRIPTION
Adding new `java/path-injection` improvement to query suite.
- [x] https://github.com/advanced-security/codeql-queries/pull/65#pullrequestreview-1217938353 

Putting this into default `codeql-java.qls` suite (vs [codeql-java-local.qls](https://github.com/advanced-security/codeql-queries/blob/main/java/suites/codeql-java-local.qls)) even though it is pulling in `LocalUserInput` ... as it is using it for a **sink**.