### PR TITLE
csharp - Add PRECISION: LOW security queries to super extended

### DIFF
--- a/csharp/.data/queries.json
+++ b/csharp/.data/queries.json
@@ -377,14 +377,24 @@
     "codeql/csharp/ql/src/Telemetry/SupportedExternalTaint.ql",
     "codeql/csharp/ql/src/Telemetry/UnsupportedExternalAPIs.ql",
     "codeql/csharp/ql/src/experimental/CWE-099/TaintedWebClient.ql",
+    "codeql/csharp/ql/src/experimental/CWE-918/RequestForgery.ql",
     "codeql/csharp/ql/src/experimental/Security Features/CWE-1004/CookieWithoutHttpOnly.ql",
+    "codeql/csharp/ql/src/experimental/Security Features/CWE-327/Azure/UnsafeUsageOfClientSideEncryptionVersion.ql",
     "codeql/csharp/ql/src/experimental/Security Features/CWE-614/CookieWithoutSecure.ql",
+    "codeql/csharp/ql/src/experimental/Security Features/CWE-759/HashWithoutSalt.ql",
+    "codeql/csharp/ql/src/experimental/Security Features/JsonWebTokenHandler/delegated-security-validations-always-return-true.ql",
     "codeql/csharp/ql/src/experimental/Security Features/JsonWebTokenHandler/security-validation-disabled.ql",
+    "codeql/csharp/ql/src/experimental/Security Features/Serialization/DefiningDatasetRelatedType.ql",
     "codeql/csharp/ql/src/experimental/Security Features/Serialization/DefiningPotentiallyUnsafeXmlSerializer.ql",
     "codeql/csharp/ql/src/experimental/Security Features/Serialization/UnsafeTypeUsedDataContractSerializer.ql",
     "codeql/csharp/ql/src/experimental/Security Features/Serialization/XmlDeserializationWithDataSet.ql",
     "codeql/csharp/ql/src/experimental/Security Features/backdoor/DangerousNativeFunctionCall.ql",
     "codeql/csharp/ql/src/experimental/Security Features/backdoor/PotentialTimeBomb.ql",
-    "codeql/csharp/ql/src/experimental/Security Features/backdoor/ProcessNameToHashTaintFlow.ql"
+    "codeql/csharp/ql/src/experimental/Security Features/backdoor/ProcessNameToHashTaintFlow.ql",
+    "codeql/csharp/ql/src/Bad Practices/LeftoverDebugCode.ql",
+    "codeql/csharp/ql/src/Security Features/CWE-020/UntrustedDataToExternalAPI.ql",
+    "codeql/csharp/ql/src/Security Features/CWE-502/UnsafeDeserialization.ql",
+    "codeql/csharp/ql/src/Security Features/CWE-611/UseXmlSecureResolver.ql",
+    "codeql/csharp/ql/src/Security Features/CWE-838/InappropriateEncoding.ql"
   ]
 }

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -7,7 +7,7 @@
 | `default` | 53 | Default Query Suite | `codeql/csharp/ql/src/codeql-suites/code-scanning` |
 | `extended` | 70 | Security Extended Suite | `codeql/csharp/ql/src/codeql-suites/security-extended` |
 | `quality` | 171 | Security and Quality Extended Suite | `codeql/csharp/ql/src/codeql-suites/security-and-quality` |
-| `super-extended` | 80 | Security Extended with Experimental and Custom Queries Suite | `advanced-security/codeql-queries/csharp/suites/codeql-csharp.qls@main` |
+| `super-extended` | 90 | Security Extended with Experimental and Custom Queries Suite | `advanced-security/codeql-queries/csharp/suites/codeql-csharp.qls@main` |
 | `audit` | 4 | Security Audit Query Suite | `advanced-security/codeql-queries/csharp/suites/codeql-csharp-audit.qls@main` |
 
 

--- a/csharp/suites/codeql-csharp.qls
+++ b/csharp/suites/codeql-csharp.qls
@@ -3,34 +3,47 @@
 
 - description: "GitHub's Field Team CodeQL CSharp extended Suite"
 
+- qlpack: github-queries-csharp
+
 - import: codeql-suites/csharp-security-extended.qls
   from: codeql/csharp-queries
 
 - queries: '.'
   from: codeql/csharp-queries
+
+# Include Experimental queries
 - include:
-    id:
-      # Web
-      - cs/webclient-path-injection
-      - cs/web/cookie-httponly-not-set
-      - cs/web/cookie-secure-not-set
-      # Json
-      - cs/json-webtoken-handler/security-validations-disabled
-      
-      # Backdoor queries
-      - cs/backdoor/dangerous-native-functions
-      - cs/backdoor/potential-time-bomb
-      - cs/backdoor/process-name-to-hash-function
+    query path:
+      - /experimental\/.*/
 
-      # Serialization
-      - cs/dataset-serialization/defining-potentially-unsafe-xml-serializer
-      - cs/dataset-serialization/unsafe-type-used-data-contract-serializer
-      - cs/dataset-serialization/xml-deserialization-with-dataset
+# Include lows
+- include:
+    kind:
+    - problem
+    - path-problem
+    tags contain:
+    - security
+    precision:
+    - low
+# 
+- include:
+    tags contain:
+    - experimental
+    - solorigate
 
-      # Solorigate
-      - cs/solorigate/modified-fnv-function-detection
-      - cs/solorigate/number-of-known-commands-in-enum-above-threshold
-      - cs/solorigate/number-of-known-hashes-above-threshold
-      - cs/solorigate/number-of-known-literals-above-threshold
-      - cs/solorigate/number-of-known-method-names-above-threshold
-      - cs/solorigate/swallow-everything-exception
+# Remove debugging, and audit queries
+- exclude:
+    tags contain:
+      - debugging
+      - audit
+# Remove local testing folders
+- exclude:
+    query path:
+      - /testing\/.*/
+- exclude:
+    deprecated: //
+- exclude:
+    query path:
+      - Metrics/Summaries/FrameworkCoverage.ql
+      - /Diagnostics/Internal/.*/
+      - /ir\/.*/


### PR DESCRIPTION
- Make super extended yolo packs more comprehensive by including low precision security queries 