### PR TITLE
Update PartialPathsFromSource.ql

### DIFF
--- a/python/debugging/PartialPathsFromSource.ql
+++ b/python/debugging/PartialPathsFromSource.ql
@@ -15,7 +15,6 @@ import semmle.python.dataflow.new.TaintTracking
 import semmle.python.Concepts
 import semmle.python.dataflow.new.RemoteFlowSources
 import semmle.python.dataflow.new.BarrierGuards
-import DataFlow::PartialPathGraph
 import semmle.python.ApiGraphs
 // Helpers
 import github.Helpers
@@ -24,18 +23,25 @@ import github.LocalSources
 private import semmle.python.security.dataflow.CommandInjectionCustomizations
 
 // Partial Graph
-class RemoteFlows extends TaintTracking::Configuration {
-  RemoteFlows() { this = "Partial Paths from Source" }
-
-  override predicate isSource(DataFlow::Node source) {
-    source instanceof RemoteFlowSource or source instanceof LocalSources::Range
+module RemoteFlowsConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
+    source instanceof CommandInjection::Source or source instanceof LocalSources::Range
   }
 
-  override int explorationLimit() { result = 10 }
+  // We need to provide `isSink`
+  predicate isSink(DataFlow::Node sink) { sink instanceof CommandInjection::Sink }
 }
 
-from RemoteFlows config, DataFlow::PartialPathNode source, DataFlow::PartialPathNode sink
-where config.hasPartialFlow(source, sink, _)
+int explorationLimit() { result = 10 }
+
+module RemoteFlows = DataFlow::Global<RemoteFlowsConfig>;
+
+module RemoteFlowsPartial = RemoteFlows::FlowExploration<explorationLimit/0>;
+
+import RemoteFlowsPartial::PartialPathGraph
+
+from RemoteFlowsPartial::PartialPathNode source, RemoteFlowsPartial::PartialPathNode sink
+where RemoteFlowsPartial::partialFlow(source, sink, _)
 // and findByLocation(source, "relative/source/path.py", 10)
 // and findByLocation(sink, "relative/sink/path.py", 10)
 select sink.getNode(), source, sink, "Partial Graph $@.", source.getNode(), "user-provided value"


### PR DESCRIPTION
Use updated version of the dataflow library.
Partial path exploration is now accessed via parameterised modules.
The path exploration module is a little secret since it cannot be documented in the signature yet.

I also changed the source to refer to the Customizations; that way the local sources is a clear addition. 