### PR TITLE
Fewer FPs, more TPs

### DIFF
--- a/python/CWE-1393/DefaultPasswordDB.ql
+++ b/python/CWE-1393/DefaultPasswordDB.ql
@@ -18,8 +18,12 @@ private import python
 import github.DefaultPasswordDB
 
 from DBColumn column, string varname, string dbname
-where column.hasDefault()
-and column.assignedToVariable() = varname
+where column.hasStaticDefault()
+and (
+    column.assignedToVariable() = varname
+    or
+    column.getColumnName() = varname
+)
 and column.getDbId() = dbname
 and varname in ["password", "secret", "key", "token", "pwd"]
 select column, "Default value in security-sensitive database '" + dbname + "' $@ assigned to variable '" + varname + "'",

--- a/python/github/DefaultPasswordDB.qll
+++ b/python/github/DefaultPasswordDB.qll
@@ -21,15 +21,23 @@ class DBColumn extends Call {
         result = id
     }
 
-    predicate hasDefault() {
-        call.getNode().getANamedArgumentName() in ["server_default", "default"]
+    predicate hasStaticDefault() {
+        exists(DictItem arg |
+            arg = call.getNode().getANamedArg()
+            and arg.(Keyword).getArg() in ["server_default", "default"]
+            and arg.(Keyword).getValue() instanceof ImmutableLiteral
+        )
     }
 
     string assignedToVariable() {
         exists(AssignStmt assign, Variable v|
             assign.defines(v)
             and v.getId() = result
-            and assign.getValue().getAChildNode*() = call.getNode()
+            and assign.getValue() = this
         )
+    }
+
+    string getColumnName() {
+        result = call.getNode().getArg(0).(StrConst).getText()
     }
 }


### PR DESCRIPTION
Fixed:
1. looking too deep into the child nodes of the assignment - just the top-level one will do
2. not looking for `db.Column('name', ...)` formatted Column creation
3. excluded non-static assignments to the default, e.g. a random generator