### PR TITLE
[GO] - Enhance go/command-injection to only consider in-use sources (net.http handler use case)

### DIFF
--- a/go/CWE-078/CommandInjection.ql
+++ b/go/CWE-078/CommandInjection.ql
@@ -1,0 +1,39 @@
+/**
+ * @name Command built from user-controlled sources
+ * @description Building a system command from user-controlled sources is vulnerable to insertion of
+ *              malicious code by the user.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 9.8
+ * @precision high
+ * @id go/command-injection
+ * @tags security
+ *       external/cwe/cwe-078
+ */
+
+import go
+import semmle.go.security.CommandInjection
+import DataFlow::PathGraph
+import semmle.go.security.FlowSources
+
+//Override CommandInjection::Configuration to use the in-use sources
+class InUseCommandInjectionConfiguration extends CommandInjection::Configuration {
+  override predicate isSource(DataFlow::Node node) {
+    exists(UntrustedFlowSource source, Function function, DataFlow::CallNode callNode |
+      source.asExpr() = node.asExpr() and
+
+      source.(DataFlow::ExprNode).asExpr().getEnclosingFunction() = function.getFuncDecl() and
+      (
+        // function is called directly
+        callNode.getACallee() = function.getFuncDecl()
+        
+        // function is passed to another function to be called
+        or callNode.getCall().getAnArgument().(Ident).refersTo(function) //NEW with 2.13.2: or c.getASyntacticArgument().asExpr().(Ident).refersTo(f)
+      )      
+    )
+  }
+}
+ 
+ from InUseCommandInjectionConfiguration cfg, CommandInjection::DoubleDashSanitizingConfiguration cfg2, DataFlow::PathNode source, DataFlow::PathNode sink
+ where (cfg.hasFlowPath(source, sink) or cfg2.hasFlowPath(source, sink))
+ select sink.getNode(), source, sink, "This command depends on a $@.", source.getNode(), "user-provided value"

--- a/go/codeql-pack.lock.yml
+++ b/go/codeql-pack.lock.yml
@@ -1,0 +1,14 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/go-all:
+    version: 0.4.1
+  codeql/go-queries:
+    version: 0.4.1
+  codeql/suite-helpers:
+    version: 0.4.1
+  codeql/tutorial:
+    version: 0.0.2
+  codeql/util:
+    version: 0.0.2
+compiled: false

--- a/go/qlpack.yml
+++ b/go/qlpack.yml
@@ -1,4 +1,7 @@
-name: github-queries-go
+---
+library: false
+name: advanced-security/codeql-go
 version: 0.1.0
 dependencies:
-  codeql/go-queries: "*"
+  codeql/go-queries: "0.4.1"
+defaultSuiteFile: suites/codeql-go.qls

--- a/tests/go-tests/CWE-078/cmdi.expected
+++ b/tests/go-tests/CWE-078/cmdi.expected
@@ -1,0 +1,10 @@
+edges
+| main.go:20:14:20:20 | selection of URL | main.go:20:14:20:28 | call to Query |
+| main.go:20:14:20:28 | call to Query | main.go:27:22:27:28 | cmdName |
+nodes
+| main.go:20:14:20:20 | selection of URL | semmle.label | selection of URL |
+| main.go:20:14:20:28 | call to Query | semmle.label | call to Query |
+| main.go:27:22:27:28 | cmdName | semmle.label | cmdName |
+subpaths
+#select
+| main.go:27:22:27:28 | cmdName | main.go:20:14:20:20 | selection of URL | main.go:27:22:27:28 | cmdName | This command depends on a $@. | main.go:20:14:20:20 | selection of URL | user-provided value |

--- a/tests/go-tests/CWE-078/cmdi.qlref
+++ b/tests/go-tests/CWE-078/cmdi.qlref
@@ -1,0 +1,1 @@
+CWE-078/CommandInjection.ql

--- a/tests/go-tests/CWE-078/go.mod
+++ b/tests/go-tests/CWE-078/go.mod
@@ -1,0 +1,3 @@
+module example.com/m/v2
+
+go 1.10

--- a/tests/go-tests/CWE-078/main.go
+++ b/tests/go-tests/CWE-078/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os/exec"
+)
+
+// func handler is unused (U1000)go-staticcheck
+func handler(req *http.Request) {
+	cmdName := req.URL.Query()["cmd"][0]
+	cmd := exec.Command(cmdName)
+	cmd.Run()
+}
+
+func usedHandler(w http.ResponseWriter, req *http.Request) {
+
+	fmt.Fprintf(w, "Welcome!!!")
+
+	cmds, ok := req.URL.Query()["cmd"]
+	if !ok || len(cmds) < 1 {
+		http.Error(w, "Missing cmd parameter", http.StatusBadRequest)
+		return
+	}
+
+	cmdName := cmds[0]
+	cmd := exec.Command(cmdName)
+	err := cmd.Run()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprintf(w, "Command '%s' executed successfully!", cmdName)
+}
+
+func justAFunction() {
+	println("I'm just a function")
+}
+
+func main() {
+	justAFunction()
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Welcome to my website!")
+	})
+
+	http.HandleFunc("/execute", usedHandler)
+
+	http.ListenAndServe(":8080", nil)
+}

--- a/tests/go-tests/qlpack.yml
+++ b/tests/go-tests/qlpack.yml
@@ -1,10 +1,8 @@
-name: github-queries-go-tests
+name: advanced-security/codeql-go-tests
 groups: [go, test]
 dependencies:
-  codeql-go: "*"
   codeql/go-all: "*"
-  github-queries-go: "*"
-  #codeql-queries/go: "*"
+  advanced-security/codeql-go: "*"
 
 extractor: go
 tests: .


### PR DESCRIPTION
Detects command built from **in-use** user-controlled sources 

[Sample App](https://github.com/vulna-felickz/testing-go-function) - this query will filter out the unused handler:
- 2 Sources in default query `go/command-injection`
   - ❌  [Not in use handler req.URL.Query](https://github.com/vulna-felickz/testing-go-function/blob/d76c2a7528563a8c40d7ab7d161be3155512915b/main.go#L11)
   - ✅ [Used Handler req.URL.Query](https://github.com/vulna-felickz/testing-go-function/blob/d76c2a7528563a8c40d7ab7d161be3155512915b/main.go#LL20C14-L20C36)
      - [Handler is registered](https://github.com/vulna-felickz/testing-go-function/blob/d76c2a7528563a8c40d7ab7d161be3155512915b/main.go#L48)

